### PR TITLE
Bugfix: comparison of numbers instead of strings

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -324,7 +324,7 @@ class AnnunciatorPanelCtrl extends MetricsPanelCtrl {
     }
 
     if (isNumber(OKLowerLimit) && isNumber(OKUpperLimit)) {
-      if (OKUpperLimit > OKLowerLimit) {
+      if (Number(OKUpperLimit) > Number(OKLowerLimit)) {
         this.panel.MetricValueRange = OKLowerLimit + ' -> ' + OKUpperLimit;
       } 
       else {


### PR DESCRIPTION
In the original code, strings were compared with the ">" operator. This led to behaviour like '12'>'2' equals false instead of true. I corrected this error.